### PR TITLE
Adds back references to footnotes

### DIFF
--- a/versions/1.1/README.md
+++ b/versions/1.1/README.md
@@ -12,15 +12,15 @@ ALI & International Institute for the Unification of Law, Principles of Transnat
 
 #### 1.2.1. Judges
 
-Each party chooses a judge and those two judges choose a third.<sup>[1](#fn1)</sup>
+Each party chooses a judge and those two judges choose a third.<a name="ref1" href="#fn1"><sup>1</sup></a>
 
 #### 1.2.2. Remedies
 
-The judges choose one party's proposed remedy.<sup>[2](#fn2)</sup>
+The judges choose one party's proposed remedy.<a name="ref2" href="#fn2"><sup>2</sup></a>
 
 #### 1.2.3. Costs
 
-The losing party pays the winning party's legal costs.<sup>[3](#fn3)</sup>
+The losing party pays the winning party's legal costs.<a name="ref3" href="#fn3"><sup>3</sup></a>
 
 ## 2. Substantive Rules
 
@@ -46,7 +46,7 @@ ALI, [Restatement of Torts, Third, Liability for Physical and Emotional Harm (20
 
 #### 2.2.1. Generally
 
-ALI, Restatement of Property (1936-40).<sup>[4](#fn4)</sup>
+ALI, Restatement of Property (1936-40).<a name="ref4" href="#fn4"><sup>4</sup></a>
 
 #### 2.2.2. Leases
 
@@ -213,11 +213,11 @@ ULC, [Uniform Real Property Electronic Recording Act (2005)](https://web.archive
 #### 2.8.3. Priority of Title to Real Property
 
 Any conveyance of an interest in real property that has not been recorded in the relevant land records office, if any, shall be void as against any subsequent transfer of a
-conflicting interest for value paid in good faith, recorded earlier.<sup>[5](#fn5)</sup>
+conflicting interest for value paid in good faith, recorded earlier.<a name="ref5" href="#fn5"><sup>5</sup></a>
 
 #### 2.8.4. Adulthood
 
-Adulthood, age of consent, majority, and capacity to contract begin 18 years after a person's birth.<sup>[6](#fn6)</sup>
+Adulthood, age of consent, majority, and capacity to contract begin 18 years after a person's birth.<a name="ref6" href="#fn6"><sup>6</sup></a>
 
 #### 2.8.5. Time Limits
 
@@ -260,7 +260,8 @@ ALI, [Model Penal Code (2009) (substantive provisions)](https://web.archive.org/
 ### 5.1. Sole Grounds for Revoking Agreement to Resolve Dispute Under Ulex. 
 
 A written agreement to resolve a dispute under Ulex shall be valid, irrevocable,
-and enforceable except upon such grounds as exist at the time of its forming in law or equity for revocation of a contract.<sup>[7](#fn7)</sup>
+and enforceable except upon such grounds as exist at the time of its forming in law or equity for revocation of a contract.
+<a name="ref7" href="#fn7"><sup>7</sup></a>
 
 ### 5.2. Sole Grounds for Modifying or Correcting Judgment Rendered Under Ulex.
 
@@ -283,40 +284,40 @@ referenced rules, and that the judgement issued as described. Absent
 application of Rules 5.1 and 5.2, above, the court receiving the motion shall
 give it the same force and effect in all respects as any judgment issued by the
 court, and the judgment shall be so treated by all persons, institutions, officers,
-or agents presented with the same.<a name="fn9"><a href="#fn9"><sup>9</sup></a></a>
+or agents presented with the same.<a name="ref9" href="#fn9"><sup>9</sup></a>
 
 ## Footnotes
 
-<a name="fn1"><sup>1</sup></a> _See,_ United Nations Commission on International Trade Law, 
+<a name="fn1" href="#ref1"><sup>1</sup></a> _See,_ United Nations Commission on International Trade Law, 
 [_UNCITRAL Model Law on International Commercial Arbitration_ Art. 10(2) (2006)](https://web.archive.org/web/20160428/http://www.uncitral.org/pdf/english/texts/arbitration/ml-arb/07-86998_Ebook.pdf) 
 (setting default number of arbitrators at 3); _id._ Art. 11(3)(a) (describing method by which panel of three arbitrators chosen). 
 _See also_ , American Arbitration Association, _Commercial Arbitration Rules and Mediation Procedures_ R-12(b) & R-13 (2013) (setting forth similar procedure).
 
-<a name="fn2"><sup>2</sup></a> _See, e.g._ , Major League Baseball, [_2012 - 2016 Basic Agreement_ Art. VI, § E(13), p.22 (2016)](https://web.archive.org/web/20160428/http://mlb.mlb.com/pa/pdf/cba_english.pdf) (visited April 28, 2016) 
+<a name="fn2" href="#ref2"><sup>2</sup></a> _See, e.g._ , Major League Baseball, [_2012 - 2016 Basic Agreement_ Art. VI, § E(13), p.22 (2016)](https://web.archive.org/web/20160428/http://mlb.mlb.com/pa/pdf/cba_english.pdf) (visited April 28, 2016) 
 ("The arbitration panel shall be limited to awarding only one or the other of the two [remedies] submitted.").
 
-<a name="fn3"><sup>3</sup></a> _See_ , American Law Institute & International Institute for the Unification of Law, 
+<a name="fn3" href="#ref3"><sup>3</sup></a> _See_ , American Law Institute & International Institute for the Unification of Law, 
 [_Principles of Transnational Civil Procedure Principle_ 25 (2004)](https://web.archive.org/web/20160430/http://www.unidroit.org/english/principles/civilprocedure/ali-unidroitprinciples-e.pdf) (codifying the rule).
 
-<a name="fn4"><sup>4</sup></a> Though the ALI no longer offers bound versions of this _Restatement_ for sale, it remains available
+<a name="fn4" href="#ref4"><sup>4</sup></a> Though the ALI no longer offers bound versions of this _Restatement_ for sale, it remains available
 via the online sources listed in footnote 3, above. It provides a few crucial rules, though much of its
 coverage has been superseded by later-published _Restatements_ covering specific areas of property
 law.
 
-<a name="fn5"><sup>5</sup></a> Here, Ulex adopts the race-notice form of recording statute most common in the United States.
+<a name="fn5" href="#ref5"><sup>5</sup></a> Here, Ulex adopts the race-notice form of recording statute most common in the United States.
 _See_ , Ray E. Sweat, _Race, Race-Notice and Notice Statutes: The American Recording System,_ 3
 PROBATE & PROPERTY 27 (May/June 1989) (cataloging popularity of various recording statutes and
 providing model race-notice statute). This rule would apply only if the adopting jurisdiction had
 created a land records office as envisioned by the ULC, Uniform Real Property Electronic Recording
 Act (2005).
 
-<a name="fn6"><sup>6</sup></a> Many of the rule sets used in Ulex invoke age-related classifications, making a uniform definition
+<a name="fn6" href="#ref6"><sup>6</sup></a> Many of the rule sets used in Ulex invoke age-related classifications, making a uniform definition
 of adulthood useful. Elsewhere, age-related classifications vary across and even within legal systems.
 Ulex sets the default at a relatively common age — 18 years old — leaving precocious children to bring
 suit for emancipation, as in ULC, _Uniform Guardianship and Protective Proceedings Act_ § 210
 (1997), or leaving adopting communities free to set a different default age for adulthood.
 
-<a name="fn7"><sup>7</sup></a> _Compare_ , Federal Arbitration Act (FAA), 9 U.S.C. § 2.
+<a name="fn7" href="#ref7"><sup>7</sup></a> _Compare_ , Federal Arbitration Act (FAA), 9 U.S.C. § 2.
 
 <a name="fn8" href="#ref8"><sup>8</sup></a> _Compare, id_. § 13.
 

--- a/versions/1.1/README.md
+++ b/versions/1.1/README.md
@@ -272,7 +272,7 @@ their authority in a manner that substantively altered their decision upon
 matters properly addressed; or 3) The judgment bears an imperfection in form
 not affecting its substance. The court may then only modify or correct the
 judgment, and then only so far as necessary to effectuate the evident intent of
-the judgment and promote justice between the parties.<a name="ref8"><sup>[8](#fn8)</sup></a>
+the judgment and promote justice between the parties.<a name="ref8" href="#fn8"><sup>8</sup></a>
 
 ### 5.3. Force and Effect of Court Confirmation. 
 
@@ -283,7 +283,7 @@ referenced rules, and that the judgement issued as described. Absent
 application of Rules 5.1 and 5.2, above, the court receiving the motion shall
 give it the same force and effect in all respects as any judgment issued by the
 court, and the judgment shall be so treated by all persons, institutions, officers,
-or agents presented with the same.<a name="ref9"><sup>[9](#fn9)</sup></a>
+or agents presented with the same.<a name="fn9"><a href="#fn9"><sup>9</sup></a></a>
 
 ## Footnotes
 
@@ -318,6 +318,6 @@ suit for emancipation, as in ULC, _Uniform Guardianship and Protective Proceedin
 
 <a name="fn7"><sup>7</sup></a> _Compare_ , Federal Arbitration Act (FAA), 9 U.S.C. § 2.
 
-<a name="fn8"><sup>[8](#ref8)</sup></a> _Compare, id_. § 13.
+<a name="fn8" href="#ref8"><sup>8</sup></a> _Compare, id_. § 13.
 
-<a name="fn9"><sup>[9](#ref9)</sup></a> _Compare, id_. § 13.
+<a name="fn9" href="#ref9"><sup>9</sup></a> _Compare, id_. § 13.

--- a/versions/1.1/README.md
+++ b/versions/1.1/README.md
@@ -272,7 +272,7 @@ their authority in a manner that substantively altered their decision upon
 matters properly addressed; or 3) The judgment bears an imperfection in form
 not affecting its substance. The court may then only modify or correct the
 judgment, and then only so far as necessary to effectuate the evident intent of
-the judgment and promote justice between the parties.<sup>[8](#fn8)</sup>
+the judgment and promote justice between the parties.<a name="ref8"><sup>[8](#fn8)</sup></a>
 
 ### 5.3. Force and Effect of Court Confirmation. 
 
@@ -283,7 +283,7 @@ referenced rules, and that the judgement issued as described. Absent
 application of Rules 5.1 and 5.2, above, the court receiving the motion shall
 give it the same force and effect in all respects as any judgment issued by the
 court, and the judgment shall be so treated by all persons, institutions, officers,
-or agents presented with the same.<sup>[9](#fn9)</sup>
+or agents presented with the same.<a name="ref9"><sup>[9](#fn9)</sup></a>
 
 ## Footnotes
 
@@ -318,6 +318,6 @@ suit for emancipation, as in ULC, _Uniform Guardianship and Protective Proceedin
 
 <a name="fn7"><sup>7</sup></a> _Compare_ , Federal Arbitration Act (FAA), 9 U.S.C. § 2.
 
-<a name="fn8"><sup>8</sup></a> _Compare, id_. § 13.
+<a name="fn8"><sup>[8](#ref8)</sup></a> _Compare, id_. § 13.
 
-<a name="fn9"><sup>9</sup></a> _Compare, id_. § 13.
+<a name="fn9"><sup>[9](#ref9)</sup></a> _Compare, id_. § 13.

--- a/versions/README.md
+++ b/versions/README.md
@@ -79,7 +79,7 @@ itself, protecting Ulex against run-time errors.
 collection of rules, offered in a new section 5, regulates the process through which a host
 sovereign's courts review and reject or adopt the judgments of Ulex courts. In form and
 effect, the Integration Module reflects the core provisions of the long-lived and widely
-respected United States Federal Arbitration Act (FAA).<sup>[1](#fn1.1.1)</sup>
+respected United States Federal Arbitration Act (FAA).<a name="ref1.1.1" href="#fn1.1.1"><sup>1</sup></a>
 Subject to scrutiny for inherently unfair adjudications, 
 the FFA gives private arbitrations force of law, allowing the prevailing
 private party to invoke public powers to enforce the private judgment. Module 5 does
@@ -87,7 +87,7 @@ likewise for decisions rendered under Ulex and presented for enforcement in the 
 host jurisdiction. In this way, special jurisdictions running Ulex can integrate more fully
 with other legal systems.
 
-<a name="fn1.1.1"><sup>1</sup></a> 9 U.S.C. § 1-ff.
+<a name="fn1.1.1" href="#ref1.1.1"><sup>1</sup></a> 9 U.S.C. § 1-ff.
 
 ## Introduction to [Version 1.0](1.0/base.txt)
 
@@ -100,12 +100,12 @@ To all these and more, Ulex offers a fair and efficient legal system.
 And like any open source program, Ulex is not doled out by the dime but instead free for anyone to
 download, use, and modify. 
 They need only adopt and implement by mutual express consent the procedural, substantive, 
-and meta-rules that follow this brief introduction.<sup>[1](#fn1.0.1)</sup>
+and meta-rules that follow this brief introduction.<a name="ref1.0.1" href="#fn1.0.1"><sup>1</sup></a>
 
 Ulex does not so much create the law as curate it, combining specialized rule sets
 from trusted sources into a simple but comprehensive legal system. 
 It covers _civil law_ in the sense of _private law_ — not in the sense of _Roman_ law 
-and not in contrast to _common law_.<sup>[2](#fn1.0.2)</sup> 
+and not in contrast to _common law_.<a name="ref1.0.2" href="#fn1.0.2"><sup>2</sup></a> 
 As such, Ulex by default does not include criminal law, which concerns not purely private
 matters, but instead offenses against the public at large. Ulex 1.0 instead offers criminal law
 as an optional module.
@@ -114,7 +114,7 @@ With regard to all areas of law, Ulex offers both _procedural_ rules, which defi
 resolve their disputes, and _substantive_ rules, which describe their legal rights and remedies. 
 A few _meta-rules_ protect the system against the functional equivalent of what
 computer programmers rue as "run-time" errors. Ulex merely sets default rules in most
-cases, leaving users free to run other legal systems "on top of" it.<sup>[3](#fn1.0.3)</sup>
+cases, leaving users free to run other legal systems "on top of" it.<a name="ref1.0.3" href="#fn1.0.3"><sup>3</sup></a>
 
 The default rules of Ulex 1.0 come from the _Restatements of the Common Law_ , the
 _Uniform Commercial Code_, and other select sources. 
@@ -122,7 +122,7 @@ To specify the rules is not to replicate them, however.
 Some of the rule sets used in Ulex remain subject to copyright claims. 
 Most such copyright claimants nonetheless make their materials publicly available. 
 Uniquely, however, the American Law Institute (ALI) both claims copyrights in the black-letter rules of
-the _Restatements_ and declines to make them publicly available.<sup>[4](#fn1.0.4)</sup> 
+the _Restatements_ and declines to make them publicly available.<a name="ref1.0.4" href="#fn1.0.4"><sup>4</sup></a> 
 Given that the Restatements constitute binding public law in the United States, 
 and that copyright cannot restrict public access to public laws, the ALI's claim looks suspect. 
 But resolution of that question must wait. 
@@ -130,17 +130,17 @@ It would at all events prove taxing to duplicate every rule of Ulex 1.0 in this 
 which instead incorporates most of its constituent rules by reference, leaving users to access
 specific provisions as the occasion requires and as they see fit.
 
-<a name="fn1.0.1"><sup>1</sup></a> For more about Ulex, see, Tom W. Bell, YOUR NEXT GOVERNMENT? FROM THE NATION STATE TO
+<a name="fn1.0.1" href="#ref1.0.1"><sup>1</sup></a> For more about Ulex, see, Tom W. Bell, YOUR NEXT GOVERNMENT? FROM THE NATION STATE TO
 STATELESS NATIONS (Cambridge University Press, 2017).
 
-<a name="fn1.0.2"><sup>2</sup></a> In fact, scholarly summations of common law rules — the various RESTATEMENTS — constitute the
+<a name="fn1.0.2" href="#ref1.0.2"><sup>2</sup></a> In fact, scholarly summations of common law rules — the various RESTATEMENTS — constitute the
 greatest part of Ulex's substantive rules.
 
-<a name="fn1.0.3"><sup>3</sup></a> See AMERICAN LAW INSTITUTE, RESTATEMENT (SECOND) OF CONFLICT OF LAWS § 187 (1971),
+<a name="fn1.0.3" href="#ref1.0.3"><sup>3</sup></a> See AMERICAN LAW INSTITUTE, RESTATEMENT (SECOND) OF CONFLICT OF LAWS § 187 (1971),
 allowing parties to specify what law controls matters within the scope of their agreement, which Ulex
 incorporates by reference at rule 2.4.1.
 
-<a name="fn1.0.44"><sup>4</sup></a> Access to the _Restatements_ can be purchased in a variety of ways and formats: 
+<a name="fn1.0.4" href="#ref1.0.4"><sup>4</sup></a> Access to the _Restatements_ can be purchased in a variety of ways and formats: 
 from [ALI](https://web.archive.org/web/20160430/https://www.ali.org/publications/#publication-type-restatements), 
 for bound versions of its publications; from Thompson Reuters, for purchase or lease of bound or e-books, at 
 [Restatements of the Law](https://web.archive.org/web/20160430/http://legalsolutions.thomsonreuters.com/law-products/Publication-Types/Restatements-of-the-Law/c/20194); 


### PR DESCRIPTION
Clicking on a footnote number will now take you back to the reference in the text.

Preview at https://macterra.github.io/Ulex/versions/1.1/